### PR TITLE
dev에서의 첫 merge 후, clubBoard 관련 연동 작업 수행

### DIFF
--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/controller/ClubBoardController.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/controller/ClubBoardController.java
@@ -53,7 +53,7 @@ public class ClubBoardController {
 
     @PutMapping("/{clubBoard-id}")
     public ResponseEntity updateClubBoard(@PathVariable ("clubBoard-id") long clubBoardId,
-                                            @RequestBody ClubBoardUpdateDto updateDto) {
+                                          @RequestBody ClubBoardUpdateDto updateDto) {
 
         ClubBoard clubBoard = mapper.updateDtoToClubBoard(updateDto);
         clubBoard.setClubBoardId(clubBoardId);

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/controller/ClubBoardController.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/controller/ClubBoardController.java
@@ -5,9 +5,16 @@ import com.codestates.main07.clubBoard.board.entity.ClubBoard;
 import com.codestates.main07.clubBoard.board.mapper.ClubBoardMapper;
 import com.codestates.main07.clubBoard.board.service.ClubBoardService;
 import com.codestates.main07.clubBoard.response.SuccessDto;
+import com.codestates.main07.jwt.auth.filter.JwtAuthenticationFilter;
+import com.codestates.main07.jwt.auth.jwt.JwtTokenizer;
+import com.codestates.main07.member.entity.Member;
+import com.codestates.main07.member.service.MemberService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.constraints.Positive;
@@ -19,16 +26,24 @@ import java.util.List;
 public class ClubBoardController {
     private final ClubBoardService service;
     private final ClubBoardMapper mapper;
+    private final JwtTokenizer jwtTokenizer;
+    private final MemberService memberService;
 
-    public ClubBoardController(ClubBoardService service, ClubBoardMapper mapper) {
+    public ClubBoardController(ClubBoardService service, ClubBoardMapper mapper, JwtTokenizer jwtTokenizer, MemberService memberService) {
         this.service = service;
         this.mapper = mapper;
+        this.jwtTokenizer = jwtTokenizer;
+        this.memberService = memberService;
     }
 
     @PostMapping
-    public ResponseEntity createClubBoard(@RequestBody ClubBoardCreateDto createDto) {
+    public ResponseEntity createClubBoard(@RequestHeader("Authorization") String authorization,
+                                          @RequestBody ClubBoardCreateDto createDto) {
 
         ClubBoard clubBoard = mapper.createDtoToClubBoard(createDto);
+        long memberId = getMemberIdFromClaims(authorization);
+        clubBoard.setMember(memberService.viewMember(memberId));
+
         ClubBoard createdClubBoard = service.createClubBoard(clubBoard);
         ClubBoardResponseDto response = mapper.clubBoardToResponseDto(createdClubBoard);
 
@@ -93,5 +108,11 @@ public class ClubBoardController {
 
         return new ResponseEntity<>(
                 new ClubBoardMultiResponseDto<>(responses, pageClubBoards, true), HttpStatus.OK);
+    }
+
+    private long getMemberIdFromClaims(String authorization) {
+        String jwtToken = authorization.substring(7);
+        Jws<Claims> claims = jwtTokenizer.getClaims(jwtToken, jwtTokenizer.getSecretKey());
+        return claims.getBody().get("memberId", Long.class);
     }
 }

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/dto/ClubBoardResponseDto.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/dto/ClubBoardResponseDto.java
@@ -18,9 +18,8 @@ public class ClubBoardResponseDto {
     private byte[] voice;
     private String category;
 
-    // member 구현 후엔 memberId 대신 nickname 사용
-    private long memberId;
-//        private String nickname;
+    // 게시글 작성자
+    private String nickname;
 
     private int viewCount;
     private LocalDateTime createdAt;

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/dto/ClubBoardResponsesDto.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/dto/ClubBoardResponsesDto.java
@@ -15,9 +15,8 @@ public class ClubBoardResponsesDto {
     private byte[] voice;
     private String category;
 
-    // member 구현 후엔 memberId 대신 nickname 사용
-    private long memberId;
-//        private String nickname;
+    // 게시글 작성자
+    private String nickname;
 
     private int viewCount;
     private LocalDateTime createdAt;

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/entity/ClubBoard.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/entity/ClubBoard.java
@@ -1,6 +1,8 @@
 package com.codestates.main07.clubBoard.board.entity;
 
+import com.codestates.main07.audit.Audit;
 import com.codestates.main07.clubBoard.comment.entity.ClubBoardComment;
+import com.codestates.main07.member.entity.Member;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,7 +14,7 @@ import java.util.List;
 @Getter
 @Setter
 @Entity
-public class ClubBoard {
+public class ClubBoard extends Audit {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long clubBoardId;
@@ -35,19 +37,11 @@ public class ClubBoard {
     @Column
     private String category;
 
-    @Column
-    private LocalDateTime createdAt = LocalDateTime.now();
-
-    @Column
-    private LocalDateTime modifiedAt = LocalDateTime.now();
-
-    @Column
-    private LocalDateTime deletedAt;
-
-    // 찾아줘 글 작성자
-    private long memberId;
-
     private int viewCount = 0;
+
+    @ManyToOne // many = board, one = member
+    @JoinColumn(columnDefinition = "member_id")
+    private Member member; // 게시글 작성자
 
     @OneToMany(mappedBy = "clubBoard") // mappedBy 에는 변수명 그대로 사용
     private List<ClubBoardComment> comments = new ArrayList<>();

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/mapper/ClubBoardMapper.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/board/mapper/ClubBoardMapper.java
@@ -6,6 +6,7 @@ import com.codestates.main07.clubBoard.board.dto.ClubBoardResponsesDto;
 import com.codestates.main07.clubBoard.board.dto.ClubBoardUpdateDto;
 import com.codestates.main07.clubBoard.board.entity.ClubBoard;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 import java.util.List;
 
@@ -13,6 +14,10 @@ import java.util.List;
 public interface ClubBoardMapper {
     ClubBoard createDtoToClubBoard(ClubBoardCreateDto createDto);
     ClubBoard updateDtoToClubBoard(ClubBoardUpdateDto updateDto);
+
+    @Mapping(source = "member.nickname", target = "nickname")
     ClubBoardResponseDto clubBoardToResponseDto(ClubBoard clubBoard);
+
+    @Mapping(source = "member.nickname", target = "nickname")
     List<ClubBoardResponsesDto> clubBoardsToResponsesDto(List<ClubBoard> clubBoards);
 }

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/controller/ClubBoardCommentController.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/controller/ClubBoardCommentController.java
@@ -7,6 +7,10 @@ import com.codestates.main07.clubBoard.comment.entity.ClubBoardComment;
 import com.codestates.main07.clubBoard.comment.mapper.ClubBoardCommentMapper;
 import com.codestates.main07.clubBoard.comment.service.ClubBoardCommentService;
 import com.codestates.main07.clubBoard.response.SuccessDto;
+import com.codestates.main07.jwt.auth.jwt.JwtTokenizer;
+import com.codestates.main07.member.service.MemberService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,18 +25,25 @@ public class ClubBoardCommentController {
     private final ClubBoardCommentService service;
     private final ClubBoardService boardService;
     private final ClubBoardCommentMapper mapper;
+    private final JwtTokenizer jwtTokenizer;
+    private final MemberService memberService;
 
-    public ClubBoardCommentController(ClubBoardCommentService service, ClubBoardCommentMapper mapper, ClubBoardService boardService) {
+    public ClubBoardCommentController(ClubBoardCommentService service, ClubBoardService boardService, ClubBoardCommentMapper mapper, JwtTokenizer jwtTokenizer, MemberService memberService) {
         this.service = service;
-        this.mapper = mapper;
         this.boardService = boardService;
+        this.mapper = mapper;
+        this.jwtTokenizer = jwtTokenizer;
+        this.memberService = memberService;
     }
 
     @PostMapping("/{clubBoards-id}/comments")
-    public ResponseEntity createComment(@PathVariable ("clubBoards-id") long clubBoardId,
+    public ResponseEntity createComment(@RequestHeader("Authorization") String authorization,
+                                        @PathVariable ("clubBoards-id") long clubBoardId,
                                         @RequestBody ClubBoardCommentCreateDto createDto) {
 
         ClubBoardComment comment = mapper.createDtoToComment(createDto);
+        long memberId = getMemberIdFromClaims(authorization);
+        comment.setMember(memberService.viewMember(memberId));
         comment.setClubBoard(boardService.findClubBoard(clubBoardId));
 
         ClubBoardComment createdComment = service.createComment(comment);
@@ -87,5 +98,11 @@ public class ClubBoardCommentController {
                                         @PathVariable ("clubBoardComment-id") long clubBoardCommentId) {
         service.deleteComment(clubBoardCommentId);
         return new ResponseEntity<>(new SuccessDto(true), HttpStatus.OK);
+    }
+
+    private long getMemberIdFromClaims(String authorization) {
+        String jwtToken = authorization.substring(7);
+        Jws<Claims> claims = jwtTokenizer.getClaims(jwtToken, jwtTokenizer.getSecretKey());
+        return claims.getBody().get("memberId", Long.class);
     }
 }

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/dto/ClubBoardCommentResponseDto.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/dto/ClubBoardCommentResponseDto.java
@@ -16,7 +16,7 @@ public class ClubBoardCommentResponseDto {
     LocalDateTime modifiedAt = LocalDateTime.now();
 
     // 댓글 작성자
-    private long memberId;
+    private String nickname;
 
     private long clubBoardId;
 }

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/dto/ClubBoardCommentResponsesDto.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/dto/ClubBoardCommentResponsesDto.java
@@ -10,20 +10,20 @@ import java.time.LocalDateTime;
 public class ClubBoardCommentResponsesDto {
     private long clubBoardCommentId;
     private String content;
-    LocalDateTime createdAt = LocalDateTime.now();
-    LocalDateTime modifiedAt = LocalDateTime.now();
+    LocalDateTime createdAt;
+    LocalDateTime modifiedAt;
 
     // 댓글 작성자
-    private long memberId;
+    private String nickname;
 
     private long clubBoardId;
 
-    public ClubBoardCommentResponsesDto(long clubBoardCommentId, String content, LocalDateTime createdAt, LocalDateTime modifiedAt, long memberId, long clubBoardId) {
+    public ClubBoardCommentResponsesDto(long clubBoardCommentId, String content, LocalDateTime createdAt, LocalDateTime modifiedAt, String nickname, long clubBoardId) {
         this.clubBoardCommentId = clubBoardCommentId;
         this.content = content;
         this.createdAt = createdAt;
         this.modifiedAt = modifiedAt;
-        this.memberId = memberId;
+        this.nickname = nickname;
         this.clubBoardId = clubBoardId;
     }
 }

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/entity/ClubBoardComment.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/entity/ClubBoardComment.java
@@ -1,6 +1,8 @@
 package com.codestates.main07.clubBoard.comment.entity;
 
+import com.codestates.main07.audit.Audit;
 import com.codestates.main07.clubBoard.board.entity.ClubBoard;
+import com.codestates.main07.member.entity.Member;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -10,7 +12,7 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @Setter
-public class ClubBoardComment {
+public class ClubBoardComment extends Audit {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long clubBoardCommentId;
@@ -18,12 +20,9 @@ public class ClubBoardComment {
     @Column(columnDefinition = "TEXT")
     private String content;
 
-    LocalDateTime createdAt = LocalDateTime.now();
-    LocalDateTime modifiedAt = LocalDateTime.now();
-    LocalDateTime deletedAt;
-
-    // 댓글 작성자
-    private long memberId;
+    @ManyToOne // many = comment, one = member
+    @JoinColumn(columnDefinition = "member_id")
+    private Member member; // 댓글 작성자
 
     @ManyToOne // many = comment, one = board
     @JoinColumn(columnDefinition = "club_board_id")

--- a/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/mapper/ClubBoardCommentMapper.java
+++ b/Server/main07/src/main/java/com/codestates/main07/clubBoard/comment/mapper/ClubBoardCommentMapper.java
@@ -17,6 +17,7 @@ public interface ClubBoardCommentMapper {
     ClubBoardComment updateDtoToComment(ClubBoardCommentUpdateDto updateDto);
 
     @Mapping(source = "clubBoard.clubBoardId", target = "clubBoardId")
+    @Mapping(source = "member.nickname", target = "nickname")
     ClubBoardCommentResponseDto commentToResponseDTo(ClubBoardComment comment);
 
     default List<ClubBoardCommentResponsesDto> commentsToResponsesDto(List<ClubBoardComment> comments) {
@@ -26,7 +27,7 @@ public interface ClubBoardCommentMapper {
                     comment.getContent(),
                     comment.getCreatedAt(),
                     comment.getModifiedAt(),
-                    comment.getMemberId(),
+                    comment.getMember().getNickname(),
                     comment.getClubBoard().getClubBoardId()));
         }
         return responsesDto;

--- a/Server/main07/src/main/java/com/codestates/main07/member/entity/Member.java
+++ b/Server/main07/src/main/java/com/codestates/main07/member/entity/Member.java
@@ -1,6 +1,8 @@
 package com.codestates.main07.member.entity;
 
 import com.codestates.main07.audit.Audit;
+import com.codestates.main07.clubBoard.board.entity.ClubBoard;
+import com.codestates.main07.clubBoard.comment.entity.ClubBoardComment;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +15,7 @@ import javax.validation.constraints.Email;
 import javax.validation.constraints.Size;
 import javax.validation.constraints.Pattern;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 
@@ -58,17 +61,11 @@ public class Member extends Audit {
 //    @LastModifiedDate
 //    private LocalDateTime modifiedAt;
 
-//    @OneToMany(mappedBy = "member")
-//    private List<MemoryBoard> memoryBoards;
-//
-//    @OneToMany(mappedBy = "member")
-//    private List<MemoryBoardAnswer> memoryBoardAnswers;
-//
-//    @OneToMany(mappedBy = "member")
-//    private List<MemoryBoardAnswerComment> memoryBoardAnswerComments;
-//
-//    @OneToMany(mappedBy = "member")
-//    private List<MemoryBoardAnswerAdopt> memoryBoardAnswerAdopts;
+    @OneToMany(mappedBy = "member")
+    private List<ClubBoard> clubBoards;
+
+    @OneToMany(mappedBy = "member")
+    private List<ClubBoardComment> clubBoardComments;
 //
 //    @OneToMany(mappedBy = "member")
 //    private List<BuySellBoard> buySellBoards;


### PR DESCRIPTION
수행한 연동 작업은 다음과 같습니다.
- clubBoard 패키지와 member 패키지의 연관관계 매핑
- clubBoard 패키지가 audit을 상속 받음
- clubBoard 패키지에서 nickname이 필요할 때, member 패키지에서 가져오도록 변경
- clubBoardController의 create 메서드에 필요한 member-id를 request header에 있는 claim에서 가져오도록 변경

연동 기능 테스트를 위해 코드를 실행하면 clubBoardRecommend의 엔티티 연관관계 매핑 쪽에서 에러가 발생합니다. 창인님께서 Recommend 연관관계 매핑 후에 다시 PR 해주시면, postman으로 테스트 해보겠습니다.

리뷰 혹은 코멘트 남겨주시면 머지하겠습니다!